### PR TITLE
Fixing typing issues and adding new support

### DIFF
--- a/docs/references/changelog.rst
+++ b/docs/references/changelog.rst
@@ -4,6 +4,11 @@
 Changelog
 ---------
 
+Version 1.0.4  - 4/19/25
+-----------------------
+
+    - Updated typing, notably on Form.create_form
+
 Version 1.0.3 - 10/05/24
 ------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "quart-wtforms"
-version = "1.0.3"
+version = "1.0.4"
 description = "Simple Integration of Quart and WTForms."
 authors = ["Chris Rood <quart.addons@gmail.com>"]
 license = "MIT"
@@ -34,7 +34,9 @@ packages = [
 python = ">=3.8"
 quart = ">=0.19"
 WTForms = ">=3.0"
+types-WTForms = ">=3.2.1.20241025"
 quart-uploads = ">=0.0.2"
+typing-extensions = { version=">=4.0.1", python = "<3.11" }
 
 [tool.poetry.group.dev.dependencies]
 pytest = "*"
@@ -73,6 +75,10 @@ warn_redundant_casts = true
 warn_return_any = false
 warn_unused_configs = true
 warn_unused_ignores = true
+
+[[tool.mypy.overrides]]
+module = "typing"
+ignore_errors = true
 
 [build-system]
 requires = ["poetry-core"]

--- a/quart_wtf/csrf.py
+++ b/quart_wtf/csrf.py
@@ -13,7 +13,7 @@ from quart import (
 )
 
 from werkzeug.exceptions import BadRequest
-from wtforms import ValidationError  # type: ignore
+from wtforms import ValidationError
 
 from .const import (
     DEFAULT_ENABLED,

--- a/quart_wtf/form.py
+++ b/quart_wtf/form.py
@@ -3,11 +3,15 @@ quart_wtf.form
 """
 from __future__ import annotations
 import asyncio
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Literal
+try:
+    from typing import Self  # type: ignore
+except ImportError:
+    from typing_extensions import Self
 
 from markupsafe import Markup
-from wtforms import Form, Field, ValidationError  # type: ignore
-from wtforms.widgets import HiddenInput  # type: ignore
+from wtforms import Form, Field, ValidationError
+from wtforms.widgets import HiddenInput
 
 from .meta import QuartFormMeta
 from .typing import FormData
@@ -16,7 +20,7 @@ from .utils import _is_submitted, _get_formdata
 _Auto = object()
 
 
-class QuartForm(Form):  # type: ignore
+class QuartForm(Form):
     """
     Quart specific subclass of WTForms :class:`~wtforms.form.Form`.
     To populate from submitted formdata use the ```.create_form``` class
@@ -65,7 +69,7 @@ class QuartForm(Form):  # type: ignore
         data: Dict | None = None,
         meta: Dict | None = None,
         **kwargs: Dict[str, Any]
-    ) -> QuartForm:
+    ) -> Self:
         """
         This creates a new instance of the form and can only be called within
         your applications routes.
@@ -114,7 +118,7 @@ class QuartForm(Form):  # type: ignore
         else:
             formdata = None
 
-        return cls(formdata, obj, prefix, data, meta, **kwargs)
+        return cls(formdata, obj, prefix, data, meta, **kwargs)  
 
     async def _validate_async(
             self, validator: Callable, field: Field
@@ -125,11 +129,11 @@ class QuartForm(Form):  # type: ignore
         try:
             await validator(self, field)
         except ValidationError as error:
-            field.errors.append(error.args[0])
+            field.errors = [error.args[0], *field.errors]
             return False
         return True
 
-    async def validate(
+    async def validate(  # type: ignore
             self, extra_validators: Dict[str, Any] | None = None
     ) -> bool:
         # pylint: disable=W0236

--- a/quart_wtf/meta.py
+++ b/quart_wtf/meta.py
@@ -2,13 +2,14 @@
 quart_wtf.meta
 """
 from __future__ import annotations
-from typing import Any
+from typing import TYPE_CHECKING, Any
+from typing_extensions import override
 
 from quart import current_app, g, session
 from werkzeug.utils import cached_property
-from wtforms import ValidationError  # type: ignore
-from wtforms.csrf.core import CSRF  # type: ignore
-from wtforms.meta import DefaultMeta  # type: ignore
+from wtforms import ValidationError
+from wtforms.csrf.core import CSRF
+from wtforms.meta import DefaultMeta
 
 from .const import (
     DEFAULT_ENABLED,
@@ -24,7 +25,7 @@ except ImportError:
     translations = None  # quart_babel not installed.
 
 
-class _QuartFormCSRF(CSRF):  # type: ignore
+class _QuartFormCSRF(CSRF):
     meta = None
 
     def setup_form(self, form):  # type: ignore
@@ -57,19 +58,20 @@ class _QuartFormCSRF(CSRF):  # type: ignore
             raise
 
 
-class QuartFormMeta(DefaultMeta):  # type: ignore
+class QuartFormMeta(DefaultMeta):
     """
     Quart specific meta class for WTForms.
     """
     csrf_class = _QuartFormCSRF
     csrf_context = session  # not used, provided for custom CSRF class.
 
-    @cached_property
-    def csrf(self) -> bool:
-        """
-        CSRF Enabled.
-        """
-        return current_app.config.get("WTF_CSRF_ENABLED", DEFAULT_ENABLED)
+    if not TYPE_CHECKING:
+        @cached_property
+        def csrf(self) -> bool:
+            """
+            CSRF Enabled.
+            """
+            return current_app.config.get("WTF_CSRF_ENABLED", DEFAULT_ENABLED)
 
     @cached_property
     def csrf_secret(self) -> Any:
@@ -80,14 +82,15 @@ class QuartFormMeta(DefaultMeta):  # type: ignore
             "WTF_CSRF_SECRET_KEY", current_app.secret_key
             )
 
-    @cached_property
-    def csrf_field_name(self) -> str:
-        """
-        CSRF field name.
-        """
-        return current_app.config.get(
-            "WTF_CSRF_FIELD_NAME", DEFAULT_CSRF_FIELD_NAME
-            )
+    if not TYPE_CHECKING:
+        @cached_property
+        def csrf_field_name(self) -> str:
+            """
+            CSRF field name.
+            """
+            return current_app.config.get(
+                "WTF_CSRF_FIELD_NAME", DEFAULT_CSRF_FIELD_NAME
+                )
 
     @cached_property
     def csrf_time_limit(self) -> int:

--- a/quart_wtf/typing.py
+++ b/quart_wtf/typing.py
@@ -7,10 +7,9 @@ from quart import Blueprint
 
 from werkzeug.datastructures import (
     CombinedMultiDict,
-    ImmutableDict,
     MultiDict
 )
 
-FormData = Union[CombinedMultiDict, ImmutableDict, MultiDict]
+FormData = Union[CombinedMultiDict, MultiDict]
 
 ViewsType = Union[str, Blueprint, Callable[..., Awaitable[Any]]]

--- a/quart_wtf/utils.py
+++ b/quart_wtf/utils.py
@@ -12,7 +12,7 @@ from urllib.parse import urlparse
 from itsdangerous import BadData, SignatureExpired, URLSafeTimedSerializer
 from quart import current_app, g, request, session
 from werkzeug.datastructures import CombinedMultiDict, ImmutableMultiDict
-from wtforms import ValidationError  # type: ignore
+from wtforms import ValidationError
 
 from .const import (
     CSRF_NOT_CONFIGURED,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """
 tests.conftest
 """
+from typing import Union
 import pytest
 from quart import Quart as _Quart
 from quart.typing import ResponseReturnValue, ResponseTypes, TestClientProtocol
@@ -12,7 +13,7 @@ class Quart(_Quart):
     Subclass of Quart for test Quart-WTF.
     """
     async def make_response(
-            self, result: ResponseReturnValue | HTTPException
+            self, result: Union[ResponseReturnValue, HTTPException]
     ) -> ResponseTypes:
         """
         Overload meth to make sure the result is never ``None``.

--- a/tests/test_csrf_form.py
+++ b/tests/test_csrf_form.py
@@ -6,7 +6,7 @@ from typing import Any
 import pytest
 from quart import Quart, g, request, session
 from quart.typing import TestClientProtocol
-from wtforms import ValidationError  # type: ignore
+from wtforms import ValidationError
 
 from quart_wtf import QuartForm
 from quart_wtf.const import (TOKEN_EXPIRED, TOKEN_INVALID, TOKEN_MISSING,

--- a/tests/test_custom_validator.py
+++ b/tests/test_custom_validator.py
@@ -4,8 +4,8 @@ tests.test_custom_validators
 import pytest
 from quart import Quart
 from quart.typing import TestClientProtocol
-from wtforms import StringField  # type: ignore
-from wtforms.validators import ValidationError  # type: ignore
+from wtforms import StringField
+from wtforms.validators import ValidationError
 
 from quart_wtf import QuartForm
 
@@ -17,14 +17,14 @@ class FormWithCustomValidators(QuartForm):
     field1 = StringField()
     field2 = StringField()
 
-    def validate_field1(self, field):  # type: ignore
+    def validate_field1(self, field: StringField) -> None:
         """
         Validates field1.
         """
         if not field.data == 'value1':
             raise ValidationError('Field value is incorrect.')
 
-    def validate_field2(self, field):  # type: ignore
+    def validate_field2(self, field: StringField) -> None:
         """
         Validates field2.
         """
@@ -40,7 +40,7 @@ async def test_custom_validator_success(
     Test custom validators with success.
     """
     @app.route('/', methods=['POST'])
-    async def index() -> None:
+    async def index() -> str:
         form = await FormWithCustomValidators().create_form()
         assert form.field1.data == 'value1'
         assert form.field2.data == 'value2'
@@ -55,6 +55,8 @@ async def test_custom_validator_success(
 
         assert form.field2.data == 'value2'
         assert 'field2' not in form.errors
+        
+        return ""
 
     await client.post('/', form={'field1': 'value1', 'field2': 'value2'})
 
@@ -67,7 +69,7 @@ async def test_custom_validator_failure(
     Test custom validators with failure.
     """
     @app.route('/', methods=['POST'])
-    async def index() -> None:
+    async def index() -> str:
         form = await FormWithCustomValidators().create_form()
         assert form.field1.data == 'xxx1'
         assert form.field2.data == 'xxx2'
@@ -81,5 +83,7 @@ async def test_custom_validator_failure(
 
         assert form.field2.data == 'xxx2'
         assert 'field2' in form.errors
+        
+        return ""
 
     await client.post('/', form={'field1': 'xxx1', 'field2': 'xxx2'})

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -2,13 +2,17 @@
 tests.test_file
 """
 from typing import Any
+import sys
 import pytest
 from quart import Quart
 from quart.datastructures import FileStorage
 from werkzeug.datastructures import MultiDict
-from wtforms import FileField as BaseFileField  # type: ignore
+from wtforms import FileField as BaseFileField
 
-from quart_uploads import UploadSet, configure_uploads  # type: ignore
+if sys.version_info < (3, 10):
+    pytest.skip("Quart-Uploads requires Python 3.10 or greater", allow_module_level=True)
+
+from quart_uploads import UploadSet, configure_uploads
 from quart_wtf import QuartForm
 from quart_wtf.file import FileAllowed, FileField, FileRequired, FileSize
 

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -7,11 +7,11 @@ import pytest
 from quart import Quart, json, request
 from quart.typing import TestClientProtocol
 
-from wtforms import (  # type: ignore
+from wtforms import (
     FileField, HiddenField, IntegerField, StringField
 )
-from wtforms.validators import DataRequired  # type: ignore
-from wtforms.widgets import HiddenInput  # type: ignore
+from wtforms.validators import DataRequired
+from wtforms.widgets import HiddenInput
 
 from quart_wtf import QuartForm
 
@@ -38,9 +38,10 @@ async def test_populate_from_form(
     Populates formdata for the form.
     """
     @app.route("/", methods=["POST"])
-    async def index() -> None:
+    async def index() -> str:
         form = await BasicForm().create_form()
         assert form.name.data == "form"
+        return ""
 
     await client.post("/", form={"name": "form"})
 
@@ -53,10 +54,11 @@ async def test_populate_from_files(
     Populates formdata for the form using files.
     """
     @app.route("/", methods=["POST"])
-    async def index() -> None:
+    async def index() -> str:
         form = await BasicForm().create_form()
         assert form.avatar.data is not None
         assert form.avatar.data.filename == "quart.png"
+        return ""
 
     await client.post(
         "/", form={"name": "files", "avatar": (BytesIO(), "quart.png")}
@@ -71,9 +73,10 @@ async def test_populate_from_json(
     Populates formdata using json.
     """
     @app.route("/", methods=["POST"])
-    async def index() -> None:
+    async def index() -> str:
         form = await BasicForm().create_form()
         assert form.name.data == "json"
+        return ""
 
     await client.post("/", json=json.dumps({"name": "json"}))
 
@@ -86,9 +89,10 @@ async def test_populate_manually(
     Manually populates the form.
     """
     @app.route("/", methods=["POST"])
-    async def index() -> None:
+    async def index() -> str:
         form = await BasicForm.create_form(fromdata=request.args)
         assert form.name.data == "args"
+        return ""
 
     await client.post("/", query_string={"name": "args"})
 
@@ -99,9 +103,10 @@ async def test_populate_none(app: Quart, client: TestClientProtocol) -> None:
     Manually populates the form with no formdata.
     """
     @app.route("/", methods=["POST"])
-    async def index() -> None:
+    async def index() -> str:
         form = BasicForm(formdata=None)
         assert form.name.data is None
+        return ""
 
     await client.post("/", data={"name": "ignore"})
 
@@ -114,11 +119,12 @@ async def test_validate_on_submit(
     Tests validate on submit for the form.
     """
     @app.route("/", methods=["POST"])
-    async def index() -> None:
+    async def index() -> str:
         form = BasicForm()
         assert form.is_submitted
         assert not await form.validate_on_submit()
         assert "name" in form.errors
+        return ""
 
     await client.post("/")
 
@@ -131,10 +137,11 @@ async def test_no_validate_on_get(
     Form not valid on GET requet.
     """
     @app.route("/", methods=["GET", "POST"])
-    async def index() -> None:
+    async def index() -> str:
         form = BasicForm()
         assert not await form.validate_on_submit()
         assert "name" not in form.errors
+        return ""
 
     await client.get("/")
 

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -5,8 +5,8 @@ import pytest
 
 from quart import Quart
 from quart.typing import TestClientProtocol
-from wtforms import StringField  # type: ignore
-from wtforms.validators import DataRequired, Length  # type: ignore
+from wtforms import StringField
+from wtforms.validators import DataRequired, Length
 
 from quart_wtf import QuartForm
 
@@ -31,13 +31,14 @@ async def test_no_extension(app: Quart, client: TestClientProtocol) -> None:
     Test that there is no babel extension.
     """
     @app.route("/", methods=["POST"])
-    async def index() -> None:
+    async def index() -> str:
         """
         Test route for the test.
         """
         form = NameForm()
         await form.validate()
         assert form.name.errors[0] == "This field is required."
+        return ""
 
     await client.post("/", headers={"Accept-Language": "zh-CN,zh;q=0.8"})
 
@@ -48,12 +49,12 @@ async def test_i18n(app: Quart, client: TestClientProtocol) -> None:
     Test i18n support for Quart_WTF.
     """
     # pylint: disable = C0415
-    from quart_babel import Babel  # type: ignore
+    from quart_babel import Babel
 
     Babel(app)
 
     @app.route("/", methods=["POST"])
-    async def index() -> None:
+    async def index() -> str:
         form = await NameForm.create_form()
         await form.validate()
 
@@ -63,6 +64,7 @@ async def test_i18n(app: Quart, client: TestClientProtocol) -> None:
             assert form.name.errors[0] == "该字段是必填字段。"
         else:
             assert form.name.errors[0] == "字段长度必须至少 8 个字符。"
+        return ""
 
     await client.post("/", headers={"Accept-Language": "zh-CN,zh;q=0.8"})
     await client.post(


### PR DESCRIPTION
It's great to see the efforts that have gone into typing in Quart-WTF so far, but there is a bit more polishing that can be done. Primarily, I started this PR because QuartForm's create_form returned specifically an instance of QuartForm, not the correct class instance. My solution uses typing_extentions, which is already required by Quart anyways, and won't be adding a dependency for the vast majority of projects. I also took a shot at resolving any other typing issues I could find between what mypy and pyright complained about.